### PR TITLE
GH #296 Quickstart error when using sqlite. Using an absolute path fixes...

### DIFF
--- a/code/zato-cli/src/zato/cli/quickstart.py
+++ b/code/zato-cli/src/zato/cli/quickstart.py
@@ -200,7 +200,7 @@ class Create(ZatoCommand):
         """
 
         if args.odb_type == 'sqlite':
-            args.sqlite_path = os.path.join(args.path, 'zato.db')
+            args.sqlite_path = os.path.abspath(os.path.join(args.path, 'zato.db'))
 
         next_step = count(1)
         next_port = count(http_plain_server_port)


### PR DESCRIPTION
Apparently, Django has some problems handling relative paths in this scenario, so converting it to a full one solves the problem.
However, I've seen that all of the configuration paths that I have seen are relative, so if you feel that this breaks the standard and that we'd better look for another solution please feel free to reject this one.
