### PR TITLE
Allow defaults for odb_port and other params.

### DIFF
--- a/code/zato-common/src/zato/common/__init__.py
+++ b/code/zato-common/src/zato/common/__init__.py
@@ -49,10 +49,6 @@ except IOError:
 zato_namespace = 'https://zato.io/ns/20130518'
 zato_ns_map = {None: zato_namespace}
 
-# SQL ODB
-engine_def = '{engine}://{username}:{password}@{host}:{port}/{db_name}'
-engine_def_sqlite = 'sqlite:///{sqlite_path}'
-
 # Convenience access functions and constants.
 
 soapenv_namespace = 'http://schemas.xmlsoap.org/soap/envelope/'
@@ -549,7 +545,7 @@ class NONCE_STORE:
 class MSG_PATTERN_TYPE:
     JSON_POINTER = NameId('JSONPointer', 'json-pointer')
     XPATH = NameId('XPath', 'xpath')
-    
+
     class __metaclass__(type):
         def __iter__(self):
             return iter((self.JSON_POINTER, self.XPATH))
@@ -603,7 +599,7 @@ class PUB_SUB:
     class MESSAGE_SOURCE:
         TOPIC = NameId('Topic', 'topic')
         CONSUMER_QUEUE = NameId('Consumer queue', 'consumer-queue')
-    
+
         class __metaclass__(type):
             def __iter__(self):
                 return iter((self.TOPIC, self.CONSUMER_QUEUE))
@@ -613,7 +609,7 @@ class PUB_SUB:
         JSON = NameId('JSON', 'json')
         XML = NameId('XML', 'xml')
         DEFAULT = JSON
-    
+
         class __metaclass__(type):
             def __iter__(self):
                 return iter((self.OBJECT, self.JSON, self.XML))
@@ -621,7 +617,7 @@ class PUB_SUB:
     class URL_ITEM_TYPE:
         TOPIC = NameId('Topic', 'topic')
         MESSAGES = NameId('Messages', 'msg')
-    
+
         class __metaclass__(type):
             def __iter__(self):
                 return iter((self.TOPIC.id, self.MESSAGES.id))


### PR DESCRIPTION
Use the default port when no port is specified, also allow access without password (e.g. access could be simply restricted to a certain user on the local machine).

Also don't fail on decode database error messages in latin-1 encoding.

