### PR TITLE
real fix #559: if the value is not defined, they should not be in properties

### DIFF
--- a/code/zato-server/src/zato/server/connection/amqp/outgoing.py
+++ b/code/zato-server/src/zato/server/connection/amqp/outgoing.py
@@ -203,7 +203,8 @@ class OutgoingConnector(BaseAMQPConnector):
                 value = msg_properties.get(name) if msg_properties.get(name) else getattr(self.out_amqp, name, None)
             else:
                 value = getattr(self.out_amqp, name, None)
-            properties[name] = value
+            if value:
+                properties[name] = value
 
         headers = msg.get('headers') or {}
 


### PR DESCRIPTION
kombu does not publish messages to the queue if the values are not correctly defined