### PR TITLE
#GH778 - Disable auto send ack for mode reject

### DIFF
--- a/code/zato-server/src/zato/server/connection/amqp_.py
+++ b/code/zato-server/src/zato/server/connection/amqp_.py
@@ -42,7 +42,7 @@ _default_out_keys=('app_id', 'content_encoding', 'content_type', 'delivery_mode'
 
 no_ack = {
     AMQP.ACK_MODE.ACK.id: False,
-    AMQP.ACK_MODE.REJECT.id: True,
+    AMQP.ACK_MODE.REJECT.id: False,
 }
 
 # ################################################################################################################################


### PR DESCRIPTION
Create consumer and specify ack mode:
https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/connection/amqp_.py#L132

For reject mode will be automate send ack.

> If  enabled the messages are automatically acknowledged by the broker.
http://docs.celeryproject.org/projects/kombu/en/latest/userguide/consumers.html

Once again call for message send reject:
https://github.com/zatosource/zato/blob/main/code/zato-server/src/zato/server/connection/amqp_.py#L338