### PR TITLE
In this stage of the installation $CURDIR/bin does not exist.

### DIFF
--- a/code/_install-fedora.sh
+++ b/code/_install-fedora.sh
@@ -36,7 +36,7 @@ sudo pip install setuptools==35.0.1
 sudo pip install virtualenv==1.9.1
 sudo pip install zato-apitest
 
-virtualenv --no-pip --python=$CURDIR/bin/python2.7 .
+virtualenv --no-pip --python=python2.7 .
 
 $CURDIR/bin/python bootstrap.py
 $CURDIR/bin/buildout


### PR DESCRIPTION
A fresh installation crashes here, because the $CURDIR/bin directory is being created by the virtualenv command.