### PR TITLE
Repair Django "AppRegistryNotReady: Apps aren't loaded yet." error

### DIFF
--- a/code/zato-server/src/zato/server/service/internal/helpers.py
+++ b/code/zato-server/src/zato/server/service/internal/helpers.py
@@ -14,6 +14,7 @@ from logging import DEBUG
 from pprint import pprint
 
 # Django
+import django
 from django.conf import settings
 from django.template import Context, Template
 
@@ -23,6 +24,7 @@ from zato.server.service import AsIs, Service
 # Configure Django settings when the module is picked up
 if not settings.configured:
     settings.configure()
+    django.setup()
 
 # ################################################################################################################################
 


### PR DESCRIPTION
After upgrade from 2.0.7 to 2.0.8, Django Library upgraded from 1.3 to 1.7 so this caused issues with using Template.