### PR TITLE
Allow XML channels with a GET request to have no XML parameters posted

### DIFF
--- a/code/zato-common/src/zato/common/util/__init__.py
+++ b/code/zato-common/src/zato/common/util/__init__.py
@@ -474,6 +474,8 @@ def payload_from_request(cid, request, data_format, transport):
             else:
                 if isinstance(request, objectify.ObjectifiedElement):
                     payload = request
+                elif len(request) == 0:
+                    payload = objectify.fromstring('<empty/>')
                 else:
                     payload = objectify.fromstring(request)
         elif data_format in(DATA_FORMAT.DICT, DATA_FORMAT.JSON):


### PR DESCRIPTION
This allows a simple GET to a XML channel.