### PR TITLE
Use $PY_BINARY  to install PIP on Debian-based systems. Closes zatosource/zato#955

### DIFF
--- a/code/_install-deb.sh
+++ b/code/_install-deb.sh
@@ -25,7 +25,8 @@ sudo apt-get install -y \
     build-essential curl git haproxy libbz2-dev libev-dev libev4 libevent-dev \
     libffi-dev libkeyutils-dev libldap2-dev libmemcached-dev libpq-dev \
     libsasl2-dev libssl-dev libxml2-dev libxslt1-dev libyaml-dev openssl \
-    $PY_BINARY $PY_BINARY-dev python-pip swig uuid-dev uuid-runtime wget zlib1g-dev lsb-release
+    $PY_BINARY $PY_BINARY-dev $PY_BINARY-pip swig uuid-dev uuid-runtime wget \
+    zlib1g-dev lsb-release
 
 # On Debian and Ubuntu the binary goes to /usr/sbin/haproxy so we need to
 # symlink it to a directory that can be easily found on PATH so that starting


### PR DESCRIPTION
When installing Zato from sources on a Debian-based system, the PIP package should be python-pip when working on Pyhton 2.7 and python3-pip when using Python 3. This is accomplished by using the existing variable $PY_BINARY to build the package name.