### PR TITLE
Sap fixes

### DIFF
--- a/code/zato-server/src/zato/server/base/parallel/config.py
+++ b/code/zato-server/src/zato/server/base/parallel/config.py
@@ -162,7 +162,7 @@ class ConfigLoader(object):
 
         # SAP RFC
         query = self.odb.get_out_sap_list(server.cluster.id, True)
-        self.config.out_sap = ConfigDict.from_query('out_sap', query)
+        self.config.out_sap = ConfigDict.from_query('out_sap', query, decrypt_func=self.decrypt)
 
          # Plain HTTP
         query = self.odb.get_http_soap_list(server.cluster.id, 'outgoing', 'plain_http', True)


### PR DESCRIPTION
I ran into some problem with the SAP connector on the current support/3.0 branch. A missing decrypt_func that crashed zato when restarted after a config change. And a connection wrapper that needed to inherit from the base Wrapper.
