### PR TITLE
Update new relic version to one that is supported for branch [support/3.0]

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -78,7 +78,7 @@ mock==1.0.1
 ndg-httpsclient==0.4.0
 netaddr==0.7.11
 netifaces==0.10.4
-newrelic==2.20.0.17
+newrelic==4.20.1.121
 nltk==3.2.1
 nose==1.3.3
 numpy==1.14.5


### PR DESCRIPTION
fixes #973 for 3.0