### PR TITLE
Fix email create

### DIFF
--- a/code/zato-server/src/zato/server/connection/jms_wmq/jms/connection.py
+++ b/code/zato-server/src/zato/server/connection/jms_wmq/jms/connection.py
@@ -246,6 +246,7 @@ class WebSphereMQConnection(object):
 
             kwargs = {}
             cd = self.mq.cd()
+            cd.MaxMsgLength = 20971520
             cd.ChannelName = self.channel
             cd.ConnectionName = conn_name.encode('utf8')
             cd.ChannelType = self.CMQC.MQCHT_CLNTCONN

--- a/code/zato-web-admin/src/zato/admin/templates/zato/email/imap.html
+++ b/code/zato-web-admin/src/zato/admin/templates/zato/email/imap.html
@@ -174,7 +174,6 @@
                             </td>
                         </tr>
                     </table>
-                    <input type="hidden" name="is_active" value="on" />
                     <input type="hidden" id="cluster_id" name="cluster_id" value="{{ cluster_id }}" />
                 </form>
             </div>
@@ -236,7 +235,6 @@
                             </td>
                         </tr>
                     </table>
-                    <input type="hidden" name="is_active" value="on" />
                     <input type="hidden" id="id_edit-cluster_id" name="cluster_id" value="{{ cluster_id }}" />
                     <input type="hidden" id="id_edit-id" name="id" />
                 </form>

--- a/code/zato-web-admin/src/zato/admin/templates/zato/email/smtp.html
+++ b/code/zato-web-admin/src/zato/admin/templates/zato/email/smtp.html
@@ -172,7 +172,6 @@
                             </td>
                         </tr>
                     </table>
-                    <input type="hidden" name="is_active" value="on" />
                     <input type="hidden" id="cluster_id" name="cluster_id" value="{{ cluster_id }}" />
                 </form>
             </div>
@@ -231,7 +230,6 @@
                             </td>
                         </tr>
                     </table>
-                    <input type="hidden" name="is_active" value="on" />
                     <input type="hidden" id="id_edit-cluster_id" name="cluster_id" value="{{ cluster_id }}" />
                     <input type="hidden" id="id_edit-id" name="id" />
                 </form>


### PR DESCRIPTION
fix createn error active email.
how to call - create email with is_active-checked
if we create active email, zato admin raise next error.
cause of provlem - two field is_active on form. zato recive string with array of values "['on','on']".

> Traceback (most recent call last):
>   File "/opt/zato_dir/zato/code/zato-web-admin/src/zato/admin/web/views/__init__.py", line 503, in __call__
>     response = self.req.zato.client.invoke(self.service_name, self.input_dict)
>   File "/opt/zato_dir/zato/code/zato-web-admin/src/zato/admin/middleware.py", line 82, in invoke
>     raise Exception('CID: {}\nDetails: {}'.format(zato_env.get('cid'), zato_env.get('details')))
> Exception: CID: 01012c25e7f5c53966d41880
> Details: Traceback (most recent call last):
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/sio.py", line 437, in convert_sio
>     value = asbool(value or None) # value can be an empty string and asbool chokes on that
>   File "/opt/zato_dir/zato/code/lib/python3.6/site-packages/paste/util/converters.py", line 16, in asbool
>     "String is not true/false: %r" % obj)
> ValueError: String is not true/false: "['on', 'on']"
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/__init__.py", line 299, in get_params
>     True, self.encrypt_func, self.encrypt_secrets, self.params_priority)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/sio.py", line 590, in convert_param
>     None, data_format, False)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/sio.py", line 470, in convert_sio
>     param, param_name, repr(value), type(value), format_exc(e))
>   File "/usr/lib/python3.6/traceback.py", line 167, in format_exc
>     return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
>   File "/usr/lib/python3.6/traceback.py", line 121, in format_exception
>     type(value), value, tb, limit=limit).format(chain=chain))
>   File "/usr/lib/python3.6/traceback.py", line 509, in __init__
>     capture_locals=capture_locals)
>   File "/usr/lib/python3.6/traceback.py", line 338, in extract
>     if limit >= 0:
> TypeError: '>=' not supported between instances of 'ValueError' and 'int'
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/connection/http_soap/channel.py", line 356, in dispatch
>     payload, worker_store, self.simple_io_config, post_data, path_info, soap_action)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/connection/http_soap/channel.py", line 627, in handle
>     params_priority=channel_item.params_pri)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 735, in update_handle
>     raise e if isinstance(e, Exception) else Exception(e)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 683, in update_handle
>     self._invoke(service, channel)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 570, in _invoke
>     service.handle()
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/internal/service.py", line 368, in handle
>     response = func(id_, payload, channel, data_format, transport, serialize=True)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 815, in invoke
>     return self.invoke_by_impl_name(self.server.service_store.name_to_impl_name[name], *args, **kwargs)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 791, in invoke_by_impl_name
>     out = self.update_handle(*invoke_args, **kwargs)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 629, in update_handle
>     wmq_ctx=kwargs.get('wmq_ctx'), channel_info=kwargs.get('channel_info'))
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 1194, in update
>     service._init(channel_type in _wsgi_channels)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/internal/__init__.py", line 86, in _init
>     super(AdminService, self)._init(is_http)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/__init__.py", line 525, in _init
>     self.server.encrypt)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/__init__.py", line 223, in init
>     self.init_flat_sio(cid, sio, data_format, transport, wsgi_environ, required_list)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/__init__.py", line 269, in init_flat_sio
>     required_list, use_channel_params_only, path_prefix, default_value, use_text))
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/__init__.py", line 310, in get_params
>     raise ParsingException(msg)
> zato.common.ParsingException: <ParsingException at 0x7f0a96965888 cid:`Caught an exception, param:`<Boolean at 0x7f0a9ff8efd0 name:[is_active]>`, params_to_visit:`(<Boolean at 0x7f0a9ff8ec18 name:[is_debug]>, 'host', <Integer at 0x7f0a9ff8ee48 name:[timeout]>, 'ping_address', 'mode', 'cluster_id', <Integer at 0x7f0a9ff8eda0 name:[port]>, <Boolean at 0x7f0a9ff8efd0 name:[is_active]>, 'name')`, has_simple_io_config:`True`, e:`Traceback (most recent call last):
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/sio.py", line 437, in convert_sio
>     value = asbool(value or None) # value can be an empty string and asbool chokes on that
>   File "/opt/zato_dir/zato/code/lib/python3.6/site-packages/paste/util/converters.py", line 16, in asbool
>     "String is not true/false: %r" % obj)
> ValueError: String is not true/false: "['on', 'on']"
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/__init__.py", line 299, in get_params
>     True, self.encrypt_func, self.encrypt_secrets, self.params_priority)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/sio.py", line 590, in convert_param
>     None, data_format, False)
>   File "/opt/zato_dir/zato/code/zato-server/src/zato/server/service/reqresp/sio.py", line 470, in convert_sio
>     param, param_name, repr(value), type(value), format_exc(e))
>   File "/usr/lib/python3.6/traceback.py", line 167, in format_exc
>     return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
>   File "/usr/lib/python3.6/traceback.py", line 121, in format_exception
>     type(value), value, tb, limit=limit).format(chain=chain))
>   File "/usr/lib/python3.6/traceback.py", line 509, in __init__
>     capture_locals=capture_locals)
>   File "/usr/lib/python3.6/traceback.py", line 338, in extract
>     if limit >= 0:
> TypeError: '>=' not supported between instances of 'ValueError' and 'int'
> ``, msg:`None`>
