### PR TITLE
Fix windows compatibility (module sh is unix-only)

### DIFF
--- a/code/zato-common/src/zato/common/util/cli.py
+++ b/code/zato-common/src/zato/common/util/cli.py
@@ -10,17 +10,20 @@ Licensed under LGPLv3, see LICENSE.txt for terms and conditions.
 from json import dumps
 import select
 import sys
+import platform
 
+isLinux = "linux" in platform.system().lower()
 # sh
-import sh
-from sh import CommandNotFound
+if isLinux:
+    import sh
+    from sh import CommandNotFound
 
 # ################################################################################################################################
 # ################################################################################################################################
-
-if 0:
-    from sh import RunningCommand
-    from zato.common.typing_ import any_, anydict, anylist
+if isLinux:
+    if 0:
+        from sh import RunningCommand
+from zato.common.typing_ import any_, anydict, anylist
 
 # ################################################################################################################################
 # ################################################################################################################################


### PR DESCRIPTION
commit 168126e introduced the module sh, which does not support windows.
This resolved in an error when importing sh in cli.py.